### PR TITLE
Add smoke test flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Agent Instructions
+
+When modifying files in this repository, run the following command to ensure the Tecton MCP server still initializes correctly without launching a long running process:
+
+```bash
+MCP_SMOKE_TEST=1 uv run mcp run src/tecton_mcp/mcp_server/server.py
+```
+
+This command should exit immediately after showing the initialization log message.

--- a/src/tecton_mcp/mcp_server/server.py
+++ b/src/tecton_mcp/mcp_server/server.py
@@ -233,3 +233,7 @@ mcp.add_tool(
 
 logger.info("Tecton MCP Server initialized")
 
+if os.environ.get("MCP_SMOKE_TEST"):
+    logger.info("MCP_SMOKE_TEST is set. Exiting after initialization.")
+    raise SystemExit(0)
+


### PR DESCRIPTION
## Summary
- exit early from server when `MCP_SMOKE_TEST` is set
- document how to run the smoke test in `AGENTS.md`

## Testing
- `MCP_SMOKE_TEST=1 uv run mcp run src/tecton_mcp/mcp_server/server.py` *(fails: No route to host)*