### PR TITLE
update README to mention cursor restart/reload in setup section

### DIFF
--- a/.cursor/.cursor
+++ b/.cursor/.cursor
@@ -1,0 +1,1 @@
+/Users/bernardorodriguez/Desktop/Workspace/testing/tecton-mcp/.cursor

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ As of June 2025, the following is the stack ranked list of best performing Tecto
 To make sure that your integration works as expected, ask the Cursor Agent a question like the following and make sure it's properly invoking your Tecton MCP tools:
 > Query Tecton's Examples Index and tell me something about BatchFeatureViews and how they differ from StreamFeatureViews. Also look at the SDK Reference.
 
+If no calls are made to Tecton MCP tools, you may need to restart Cursor or reload your Cursor window to ensure new tools are properly registered.
+
 ### Start AI-Assisted Feature Engineering :-)
 
 Now you can go to your **Feature Repository** in Cursor and start using Tecton's Co-Pilot - directly integrated in Cursor.


### PR DESCRIPTION
When I went through the setup process, Cursor MCP Tools in the screenshot showed 0 tools enabled. It was fixed after restarting.

<img width="477" alt="Screenshot 2025-06-06 at 11 22 01 AM" src="https://github.com/user-attachments/assets/3a11fa42-1a5c-45a2-a6cc-ceb103d4026a" />
