### PR TITLE
Add Metrics API v1 support to tecton-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,8 @@ The Tecton MCP server exposes the following tools that can be used by an MCP cli
 | `query_documentation_index_tool`        | Retrieves Tecton documentation snippets based on a query. Provides context directly from Tecton's official documentation.       |
 | `get_full_tecton_sdk_reference_tool`    | Fetches the complete Tecton SDK reference, including all available classes and functions. Use when a broad overview of the SDK is needed. |
 | `query_tecton_sdk_reference_tool`       | Fetches the Tecton SDK reference for a specified list of classes or functions. Ideal for targeted information on specific SDK components.   |
-
-> ℹ️ **Feature Services**: If the MCP server is configured with a `TECTON_API_KEY` environment variable, the MCP server will register Tecton Feature Services as tools. This makes it possible for agents to query online feature services for fresh features from batch, streaming and real-time data sources.
-
+| `query_tecton_metrics_tool`             | Queries the Tecton Metrics API. Returns point-in-time system metrics in human-readable or raw OpenMetrics format. |
+> ℹ️ **API-based Tools**: If the MCP server is configured with a `TECTON_API_KEY` environment variable, the MCP server will register additional API-based tools including Tecton Feature Services and the Metrics API tool. This makes it possible for agents to query online feature services for fresh features from batch, streaming and real-time data sources and access system metrics.
 ## Prerequisites
 
 1. Install the `uv` package manager:

--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ The Tecton MCP server exposes the following tools that can be used by an MCP cli
 | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | `query_example_code_snippet_index_tool` | Finds relevant Tecton code examples using a vector database. Helpful for finding usage patterns before writing new Tecton code.           |
 | `query_documentation_index_tool`        | Retrieves Tecton documentation snippets based on a query. Provides context directly from Tecton's official documentation.       |
-| `get_full_tecton_sdk_reference_tool`    | Fetches the complete Tecton SDK reference, including all available classes and functions. Use when a broad overview of the SDK is needed. |
+|    `get_full_tecton_sdk_reference_tool`    | Fetches the complete Tecton SDK reference, including all available classes and functions. Use when a broad overview of the SDK is needed. |
 | `query_tecton_sdk_reference_tool`       | Fetches the Tecton SDK reference for a specified list of classes or functions. Ideal for targeted information on specific SDK components.   |
 | `query_tecton_metrics_tool`             | Queries the Tecton Metrics API. Returns point-in-time system metrics in human-readable or raw OpenMetrics format. |
+
 > ℹ️ **API-based Tools**: If the MCP server is configured with a `TECTON_API_KEY` environment variable, the MCP server will register additional API-based tools including Tecton Feature Services and the Metrics API tool. This makes it possible for agents to query online feature services for fresh features from batch, streaming and real-time data sources and access system metrics.
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The Tecton MCP server exposes the following tools that can be used by an MCP cli
 | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | `query_example_code_snippet_index_tool` | Finds relevant Tecton code examples using a vector database. Helpful for finding usage patterns before writing new Tecton code.           |
 | `query_documentation_index_tool`        | Retrieves Tecton documentation snippets based on a query. Provides context directly from Tecton's official documentation.       |
-|    `get_full_tecton_sdk_reference_tool`    | Fetches the complete Tecton SDK reference, including all available classes and functions. Use when a broad overview of the SDK is needed. |
+| `get_full_tecton_sdk_reference_tool`    | Fetches the complete Tecton SDK reference, including all available classes and functions. Use when a broad overview of the SDK is needed. |
 | `query_tecton_sdk_reference_tool`       | Fetches the Tecton SDK reference for a specified list of classes or functions. Ideal for targeted information on specific SDK components.   |
 | `query_tecton_metrics_tool`             | Queries the Tecton Metrics API. Returns point-in-time system metrics in human-readable or raw OpenMetrics format. |
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ The Tecton MCP server exposes the following tools that can be used by an MCP cli
 | `query_documentation_index_tool`        | Retrieves Tecton documentation snippets based on a query. Provides context directly from Tecton's official documentation.       |
 | `get_full_tecton_sdk_reference_tool`    | Fetches the complete Tecton SDK reference, including all available classes and functions. Use when a broad overview of the SDK is needed. |
 | `query_tecton_sdk_reference_tool`       | Fetches the Tecton SDK reference for a specified list of classes or functions. Ideal for targeted information on specific SDK components.   |
-
-> ℹ️ **Feature Services**: If the MCP server is configured with a `TECTON_API_KEY` environment variable, the MCP server will register Tecton Feature Services as tools. This makes it possible for agents to query online feature services for fresh features from batch, streaming and real-time data sources.
+| `query_tecton_metrics_tool`             | Queries the Tecton Metrics API. Returns point-in-time system metrics in human-readable or raw OpenMetrics format. |
+> ℹ️ **API-based Tools**: If the MCP server is configured with a `TECTON_API_KEY` environment variable, the MCP server will register additional API-based tools including Tecton Feature Services and the Metrics API tool. This makes it possible for agents to query online feature services for fresh features from batch, streaming and real-time data sources and access system metrics.
 
 ## Architecture
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ dependencies = [
     "debugpy>=1.8.11",
     "pyarrow==15.0.2",
     "tecton>=0.8.0a0",
-    "tecton-client"
+    "tecton-client",
+    "requests>=2.31.0",
+    "prometheus-client>=0.19.0"
 ]
 readme = "README.md"
 requires-python = ">=3.11,<3.12"

--- a/src/tecton_mcp/mcp_server/server.py
+++ b/src/tecton_mcp/mcp_server/server.py
@@ -18,6 +18,7 @@ from tecton_mcp.tools.documentation_tools import load_documentation_index
 from tecton_mcp.tools.feature_service_tool_library import (
     register_tecton_feature_service_as_tools,
 )
+from tecton_mcp.tools.metrics_api_tools import register_metrics_api_tool
 from tecton_mcp.embed.meta import get_embedding_model
 from tecton_mcp.utils.sdk_introspector import get_sdk_definitions
 from tecton._internals.sdk_decorators import sdk_public_method
@@ -237,14 +238,20 @@ mcp.add_tool(
 import tecton
 from tecton._internals.utils import cluster_url
 
-# Only register FeatureServices as tools if TECTON_API_KEY is set
+# Only register API-based tools if TECTON_API_KEY is set
 if os.environ.get("TECTON_API_KEY"):
     current_workspace = tecton.get_current_workspace()
     tecton_cluster_url = cluster_url()
+    
+    # Register Feature Services
     register_tecton_feature_service_as_tools(current_workspace, mcp, tecton_cluster_url)
     logger.info("FeatureServices registered as tools")
+    
+    # Register Metrics API tool
+    register_metrics_api_tool(mcp, tecton_cluster_url)
+    logger.info("Metrics API tool registered")
 else:
-    logger.warning("No TECTON_API_KEY found - FeatureServices will not be registered as tools")
+    logger.warning("No TECTON_API_KEY found - API-based tools will not be registered")
 
 logger.info("Tecton MCP Server initialized")
 

--- a/src/tecton_mcp/tools/metrics_api_tools.py
+++ b/src/tecton_mcp/tools/metrics_api_tools.py
@@ -1,0 +1,191 @@
+"""
+Tools for querying Tecton observability metrics.
+This module provides functionality to query the Tecton metrics API endpoint.
+"""
+
+import logging
+import os
+import re
+from typing import Optional, Dict, List, Any
+import requests
+from prometheus_client.parser import text_string_to_metric_families
+
+logger = logging.getLogger(__name__)
+
+
+def get_tecton_cluster_url() -> str:
+    """Get the current Tecton cluster URL."""
+    import tecton
+    from tecton._internals.utils import cluster_url
+    return cluster_url()
+
+
+def parse_openmetrics_to_readable(
+    metrics_text: str, 
+    metric_filter: Optional[str] = None
+) -> str:
+    """
+    Parse OpenMetrics format text and convert to human-readable format.
+    
+    Args:
+        metrics_text: Raw OpenMetrics response text
+        metric_filter: Optional regex pattern to filter metrics
+        
+    Returns:
+        Formatted string with current metrics
+    """
+    parsed_metrics = []
+    
+    try:
+        # Use the official Prometheus client parser
+        for metric_family in text_string_to_metric_families(metrics_text):
+            metric_name = metric_family.name
+            
+            # Apply filter if specified
+            if metric_filter:
+                try:
+                    if not re.search(metric_filter, metric_name):
+                        continue
+                except re.error as e:
+                    logger.warning(f"Invalid regex pattern '{metric_filter}': {e}")
+                    # Skip filtering on invalid regex
+                    continue
+            
+            # Process each sample in the metric family
+            for sample in metric_family.samples:
+                # Convert labels dict to a more readable format
+                labels = {}
+                if sample.labels:
+                    labels = dict(sample.labels)
+                
+                parsed_metrics.append({
+                    'name': sample.name,
+                    'value': sample.value,
+                    'labels': labels,
+                    'timestamp': None  # Prometheus parser doesn't preserve timestamps
+                })
+    
+    except Exception as e:
+        logger.error(f"Error parsing OpenMetrics text: {e}")
+        return f"Error parsing metrics: {e}"
+    
+    # Sort by metric name for consistent output
+    parsed_metrics.sort(key=lambda x: x['name'])
+    
+    # Format output
+    if not parsed_metrics:
+        return "No metrics found matching the filter criteria."
+    
+    output = ["Current Tecton Metrics:"]
+    
+    for metric in parsed_metrics:
+        metric_line = f"- {metric['name']}: {metric['value']}"
+        
+        if metric['labels']:
+            label_str = ", ".join([f"{k}={v}" for k, v in metric['labels'].items()])
+            metric_line += f" ({label_str})"
+            
+        output.append(metric_line)
+    
+    return "\n".join(output)
+
+
+def query_tecton_metrics(
+    metric_filter: Optional[str] = None,
+    output_format: str = "formatted"
+) -> str:
+    """
+    Query current Tecton metrics from the observability endpoint.
+    
+    Args:
+        metric_filter: Optional regex pattern to filter metrics
+        output_format: "raw" for OpenMetrics format, "formatted" for human-readable
+        
+    Returns:
+        String containing the metrics data
+    """
+    api_key = os.environ.get("TECTON_API_KEY")
+    if not api_key:
+        return "Error: TECTON_API_KEY environment variable not set"
+    
+    try:
+        # Get cluster URL
+        cluster_url = get_tecton_cluster_url()
+        metrics_url = f"{cluster_url}/api/v1/observability/metrics"
+        
+        headers = {
+            "Authorization": f"Tecton-key {api_key}"
+        }
+        
+        logger.info(f"Querying metrics from: {metrics_url}")
+        response = requests.get(metrics_url, headers=headers, timeout=30)
+        response.raise_for_status()
+        
+        # Get the raw metrics data
+        metrics_data = response.text
+        
+        if output_format == "raw":
+            return metrics_data
+        
+        # Parse and format for human readability
+        return parse_openmetrics_to_readable(metrics_data, metric_filter)
+        
+    except requests.exceptions.HTTPError as e:
+        if e.response.status_code == 401:
+            return "Error: Authentication failed. Please check your TECTON_API_KEY."
+        elif e.response.status_code == 403:
+            return "Error: Access denied. Your API key may not have permission to access metrics."
+        else:
+            return f"Error fetching metrics: HTTP {e.response.status_code} - {e.response.text}"
+    except requests.exceptions.Timeout:
+        return "Error: Request timed out while fetching metrics."
+    except requests.exceptions.ConnectionError:
+        return "Error: Could not connect to Tecton cluster. Please check your network connection."
+    except Exception as e:
+        logger.error(f"Unexpected error querying metrics: {e}")
+        return f"Unexpected error: {e}"
+
+
+def register_metrics_api_tool(mcp_server, cluster_url: str) -> None:
+    """
+    Register the metrics API tool with the MCP server.
+    
+    Args:
+        mcp_server: The FastMCP server instance
+        cluster_url: The Tecton cluster URL
+    """
+    from mcp.server.fastmcp import Context
+    from tecton._internals.sdk_decorators import sdk_public_method
+    
+    @mcp_server.tool()
+    @sdk_public_method
+    def query_tecton_metrics_tool(
+        metric_filter: Optional[str] = None,
+        output_format: str = "formatted",
+        ctx: Context = None
+    ) -> str:
+        """
+        Query current Tecton metrics from the observability endpoint.
+        
+        This tool fetches point-in-time metrics from Tecton's Prometheus-compatible
+        scrape endpoint. It returns current system state, not historical data.
+        
+        Args:
+            metric_filter: Optional regex pattern to filter metrics (e.g., "tecton_feature_store.*")
+            output_format: "raw" for OpenMetrics format, "formatted" for human-readable
+            
+        Returns:
+            String containing the current metrics data
+            
+        Examples:
+            - Get all current metrics: query_tecton_metrics_tool()
+            - Get only feature store metrics: query_tecton_metrics_tool(metric_filter="tecton_feature_store.*")
+            - Get materialization metrics: query_tecton_metrics_tool(metric_filter="tecton_materialization.*")
+            - Get raw OpenMetrics format: query_tecton_metrics_tool(output_format="raw")
+        """
+        if ctx:
+            ctx.info(f"Querying Tecton metrics with filter: {metric_filter}, output_format: {output_format}")
+        
+        return query_tecton_metrics(metric_filter, output_format)
+    
+    logger.info("Metrics API tool registered successfully") 

--- a/tests/test_metrics_api_tools.py
+++ b/tests/test_metrics_api_tools.py
@@ -1,0 +1,195 @@
+"""
+Unit tests for metrics API tools.
+"""
+
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+from tecton_mcp.tools.metrics_api_tools import (
+    parse_openmetrics_to_readable,
+    query_tecton_metrics,
+    get_tecton_cluster_url
+)
+
+
+class TestParseOpenMetricsToReadable:
+    """Test the OpenMetrics parsing functionality."""
+    
+    def test_parse_simple_metrics(self):
+        """Test parsing simple metrics without labels."""
+        metrics_text = """
+# HELP tecton_feature_store_requests_total Total number of feature store requests
+# TYPE tecton_feature_store_requests_total counter
+tecton_feature_store_requests_total 1234
+tecton_materialization_jobs_running 5
+"""
+        result = parse_openmetrics_to_readable(metrics_text)
+        
+        assert "Current Tecton Metrics:" in result
+        assert "tecton_feature_store_requests_total: 1234.0" in result
+        assert "tecton_materialization_jobs_running: 5.0" in result
+    
+    def test_parse_metrics_with_labels(self):
+        """Test parsing metrics with labels."""
+        metrics_text = """
+# HELP tecton_feature_store_latency_seconds Feature store latency
+# TYPE tecton_feature_store_latency_seconds histogram
+tecton_feature_store_latency_seconds{quantile="0.5",service="online"} 0.045
+tecton_feature_store_latency_seconds{quantile="0.95",service="online"} 0.123
+"""
+        result = parse_openmetrics_to_readable(metrics_text)
+        
+        assert "tecton_feature_store_latency_seconds: 0.045" in result
+        assert "quantile=0.5, service=online" in result
+        assert "tecton_feature_store_latency_seconds: 0.123" in result
+        assert "quantile=0.95, service=online" in result
+    
+    def test_parse_metrics_always_includes_labels(self):
+        """Test that metrics always include labels when present."""
+        metrics_text = """
+# HELP tecton_feature_store_latency_seconds Feature store latency
+# TYPE tecton_feature_store_latency_seconds histogram
+tecton_feature_store_latency_seconds{quantile="0.5",service="online"} 0.045
+"""
+        result = parse_openmetrics_to_readable(metrics_text)
+        
+        assert "tecton_feature_store_latency_seconds: 0.045" in result
+        assert "quantile=0.5, service=online" in result
+    
+    def test_filter_metrics(self):
+        """Test filtering metrics with regex pattern."""
+        metrics_text = """
+# HELP tecton_feature_store_requests_total Total requests
+# TYPE tecton_feature_store_requests_total counter
+tecton_feature_store_requests_total 1234
+# HELP tecton_materialization_jobs_running Running jobs
+# TYPE tecton_materialization_jobs_running gauge
+tecton_materialization_jobs_running 5
+# HELP tecton_feature_store_latency_seconds Latency
+# TYPE tecton_feature_store_latency_seconds histogram
+tecton_feature_store_latency_seconds 0.045
+"""
+        result = parse_openmetrics_to_readable(metrics_text, metric_filter="tecton_feature_store.*")
+        
+        assert "tecton_feature_store_requests_total: 1234.0" in result
+        assert "tecton_feature_store_latency_seconds: 0.045" in result
+        assert "tecton_materialization_jobs_running" not in result
+    
+    def test_no_metrics_found(self):
+        """Test handling when no metrics match the filter."""
+        metrics_text = """
+# HELP tecton_feature_store_requests_total Total requests
+# TYPE tecton_feature_store_requests_total counter
+tecton_feature_store_requests_total 1234
+"""
+        result = parse_openmetrics_to_readable(metrics_text, metric_filter="nonexistent.*")
+        
+        assert "No metrics found matching the filter criteria." in result
+
+
+class TestQueryTectonMetrics:
+    """Test the metrics querying functionality."""
+    
+    @patch.dict(os.environ, {}, clear=True)
+    def test_no_api_key(self):
+        """Test behavior when TECTON_API_KEY is not set."""
+        result = query_tecton_metrics()
+        assert "Error: TECTON_API_KEY environment variable not set" in result
+    
+    @patch.dict(os.environ, {"TECTON_API_KEY": "test-key"})
+    @patch('tecton_mcp.tools.metrics_api_tools.get_tecton_cluster_url')
+    @patch('requests.get')
+    def test_successful_query(self, mock_get, mock_cluster_url):
+        """Test successful metrics query."""
+        mock_cluster_url.return_value = "https://test.tecton.ai"
+        
+        mock_response = MagicMock()
+        mock_response.text = """
+# HELP tecton_feature_store_requests_total Total requests
+# TYPE tecton_feature_store_requests_total counter
+tecton_feature_store_requests_total 1234
+# HELP tecton_materialization_jobs_running Running jobs
+# TYPE tecton_materialization_jobs_running gauge
+tecton_materialization_jobs_running 5
+"""
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+        
+        result = query_tecton_metrics()
+        
+        assert "Current Tecton Metrics:" in result
+        assert "tecton_feature_store_requests_total: 1234.0" in result
+        assert "tecton_materialization_jobs_running: 5.0" in result
+        
+        # Verify the request was made correctly
+        mock_get.assert_called_once_with(
+            "https://test.tecton.ai/api/v1/observability/metrics",
+            headers={"Authorization": "Tecton-key test-key"},
+            timeout=30
+        )
+    
+    @patch.dict(os.environ, {"TECTON_API_KEY": "test-key"})
+    @patch('tecton_mcp.tools.metrics_api_tools.get_tecton_cluster_url')
+    @patch('requests.get')
+    def test_raw_format(self, mock_get, mock_cluster_url):
+        """Test querying with raw format."""
+        mock_cluster_url.return_value = "https://test.tecton.ai"
+        
+        mock_response = MagicMock()
+        mock_response.text = "raw_metrics_data"
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+        
+        result = query_tecton_metrics(output_format="raw")
+        
+        assert result == "raw_metrics_data"
+    
+    @patch.dict(os.environ, {"TECTON_API_KEY": "test-key"})
+    @patch('tecton_mcp.tools.metrics_api_tools.get_tecton_cluster_url')
+    @patch('requests.get')
+    def test_authentication_error(self, mock_get, mock_cluster_url):
+        """Test handling of authentication errors."""
+        mock_cluster_url.return_value = "https://test.tecton.ai"
+        
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "Unauthorized"
+        
+        mock_get.return_value = mock_response
+        mock_get.side_effect = requests.exceptions.HTTPError(response=mock_response)
+        
+        result = query_tecton_metrics()
+        
+        assert "Error: Authentication failed" in result
+    
+    @patch.dict(os.environ, {"TECTON_API_KEY": "test-key"})
+    @patch('tecton_mcp.tools.metrics_api_tools.get_tecton_cluster_url')
+    @patch('requests.get')
+    def test_permission_error(self, mock_get, mock_cluster_url):
+        """Test handling of permission errors."""
+        mock_cluster_url.return_value = "https://test.tecton.ai"
+        
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.text = "Forbidden"
+        
+        mock_get.return_value = mock_response
+        mock_get.side_effect = requests.exceptions.HTTPError(response=mock_response)
+        
+        result = query_tecton_metrics()
+        
+        assert "Error: Access denied" in result
+
+
+class TestGetTectonClusterUrl:
+    """Test the cluster URL retrieval functionality."""
+    
+    @patch('tecton_mcp.tools.metrics_api_tools.cluster_url')
+    def test_get_cluster_url(self, mock_cluster_url):
+        """Test getting the cluster URL."""
+        mock_cluster_url.return_value = "https://test.tecton.ai"
+        
+        result = get_tecton_cluster_url()
+        
+        assert result == "https://test.tecton.ai"
+        mock_cluster_url.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -1196,6 +1196,15 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/cf/40dde0a2be27cc1eb41e333d1a674a74ce8b8b0457269cc640fd42b07cf7/prometheus_client-0.22.1.tar.gz", hash = "sha256:190f1331e783cf21eb60bca559354e0a4d4378facecf78f5428c39b675d20d28", size = 69746 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/ae/ec06af4fe3ee72d16973474f122541746196aaa16cea6f66d18b963c6177/prometheus_client-0.22.1-py3-none-any.whl", hash = "sha256:cca895342e308174341b2cbf99a56bef291fbc0ef7b9e5412a0f26d653ba7094", size = 58694 },
+]
+
+[[package]]
 name = "propcache"
 version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1819,7 +1828,9 @@ dependencies = [
     { name = "langchain-openai" },
     { name = "openai" },
     { name = "pandas" },
+    { name = "prometheus-client" },
     { name = "pyarrow" },
+    { name = "requests" },
     { name = "sentence-transformers" },
     { name = "tecton" },
     { name = "tecton-client" },
@@ -1849,7 +1860,9 @@ requires-dist = [
     { name = "langchain-openai", specifier = "==0.3.9" },
     { name = "openai", specifier = "==1.67.0" },
     { name = "pandas", specifier = ">=2.2.1" },
+    { name = "prometheus-client", specifier = ">=0.19.0" },
     { name = "pyarrow", specifier = "==15.0.2" },
+    { name = "requests", specifier = ">=2.31.0" },
     { name = "sentence-transformers", specifier = ">=2.2.0" },
     { name = "tecton", specifier = ">=0.8.0a0" },
     { name = "tecton-client" },


### PR DESCRIPTION
## Summary

Add [Metrics API v1](https://docs.tecton.ai/docs/monitoring/metrics-api) support to `tecton-mcp`. This tool is only registered if `TECTON_API_KEY` is set, which follows the same pattern as feature-services-as-tools, which are also only registered if `TECTON_API_KEY` is provided.

The endpoint queries the `/api/v1/observability/metrics` endpoint via GET request with the header, `"Authorization: Tecton-key $TECTON_API_KEY"`. It uses the [prometheus_client](https://pypi.org/project/prometheus-client/) parsing library to translate the scraped metrics to a usable format.

## Example

<img width="748" height="527" alt="image" src="https://github.com/user-attachments/assets/ff6911e1-ebd6-4910-ad4d-da0b10c65943" />

## Next Steps

Support for Metrics API v2 will be added here as it becomes stable. V2 metrics will give the user much more granular insight and ability to drill-down on specific performance issues. 