### PR TITLE
Add claude code setup to README.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,411 @@
+# Claude Configuration for Tecton Feature Development
+
+This file contains configuration and rules for Claude Code when working with Tecton feature repositories.
+
+## Tecton Feature Development Rules
+
+### General Feature Creation Guidelines
+
+- Break down feature implementation into stages:
+  1. Fetch and review relevant rules
+  2. Search for Tecton examples and API reference
+  3. Look at existing feature repository for reusable Entities and Data Sources. If you find good fits, confirm with the user that they want to reuse.
+  4. Implement the solution
+
+- **CRITICAL**: Before writing or editing feature code:
+  - You MUST call mcp_tecton_query_example_code_snippet_index_tool to look for relevant code snippets
+  - You MUST then think about all the available Tecton classes that you will use to implement the feature
+  - You MUST then call mcp_query_tecton_sdk_reference_tool to look at the exact definition of all the Tecton classes and functions you're planning to use
+  - You MUST finally come up with a plan that explains which parameters of BatchFeatureView, StreamFeatureView or RealTimeFeatureView you're planning to use based on the SDK reference
+
+### Feature View Selection Rules
+
+- For aggregations over time windows ≤ 60 minutes, default to StreamFeatureView unless specified otherwise
+- Never combine `Attribute` and `Aggregate` features in the same FeatureView
+- Only supported `mode` values: "pyspark" and "spark_sql" (Rift not supported)
+
+### SQL Handling and Data Source References
+
+- **CRITICAL**: If a user provides a SQL query for a feature: You MUST NOT translate the SQL logic into another language or API (e.g., PySpark DataFrames, Pandas) unless the user explicitly asks you to 'translate to PySpark' or 'rewrite using PySpark DataFrames'. Stick to SQL - it's ok to translate from say Snowflake SQL to Spark SQL if necessary.
+- Be very thoughtful when you change a customer provided SQL statement. Make sure you don't remove anything that may be relevant to the feature transformation.
+
+- **CRITICAL**: Every table referenced in SQL (FROM/JOIN) must be declared as a Data Source and included in sources parameter
+- When referencing data sources in SQL f-strings, use parameter names from function signature, not hardcoded table names
+- Use `unfiltered()` on BatchSource when referencing dimension tables
+- For fact tables with timestamps, only use `unfiltered()` if `incremental_backfills=True`
+
+Example:
+```python
+@batch_feature_view(
+    sources=[transactions, products.unfiltered(), stores.unfiltered()],
+)
+def feature_view_function(transactions, products, stores, context=materialization_context()):
+    return f"""
+    SELECT * FROM {transactions} t
+    JOIN {products} p ON t.product_id = p.product_id
+    JOIN {stores} s ON t.store_id = s.store_id
+    """
+```
+
+### Time and Context Rules
+
+- Never use `CURRENT_DATE()` or similar functions in transformations
+- Always use `end_time` from the context parameter
+- Never have Python comments (prefixed with "#") in SQL statements
+
+### Incremental Processing Rules
+
+- If BatchFeatureView uses GROUP BY, set `incremental_backfills=True`
+- If `incremental_backfills=True`, all sources must use `unfiltered()`
+- Handle data filtering manually in the FeatureView function when using incremental backfills
+
+### Aggregation Engine Rules
+
+- Never set `incremental_backfill=True` for FeatureViews using `Aggregate` class
+- Built-in Aggregates: approx_count_distinct, approx_percentile, count, first_distinct, first, last_distinct, last, max, mean, min, stddev_pop, stddev_samp, sum, var_pop, var_samp
+- BFVs using Aggregate features should set `incremental_materialization=False`
+
+### Snowflake Integration
+
+- Use `BatchSource` with `SnowflakeConfig` for Snowflake data sources
+
+### Entity Creation
+
+- Wrap join keys in `Field` class:
+```python
+from tecton import Entity
+from tecton.types import Field, String
+
+customer = Entity(name="Customer", join_keys=[Field("customer_id", String)])
+```
+
+### Validation and Testing
+
+- Validate implementation by running `tecton plan`
+- Ensure current directory is a Tecton repository (contains `.tecton` file)
+- Never run `tecton apply` or `tecton init` unless explicitly requested
+- Create unit tests only after successful `tecton plan` validation
+
+## Tecton Optimization Rules
+
+### Use Tecton Aggregates Over Custom Aggregations
+
+- Check if custom aggregations can be expressed using built-in Aggregate functions
+- If **all** can be mapped to Aggregate class, move them out of transformation function
+- If **only some** can be expressed, factor those into separate FeatureView
+- If aggregation **cannot** be expressed with Aggregate, use `incremental_materialization=True`
+
+### Critical Notes for Optimization
+
+- Review unit testing rules when switching to Aggregation features
+- Never change the `mode` of FeatureView when switching to Aggregation
+- Look for opportunities to filter data sources when switching to Aggregation
+- Study examples of Tecton Aggregation features before implementation
+
+## Unit Testing Rules
+
+### Prerequisites
+
+- Ensure `tecton plan` works before adding unit tests
+- Set `conf.set("TECTON_SKIP_OBJECT_VALIDATION", "True")` for mock testing
+- Always run tests with `tecton test`, never invoke `pytest` directly
+
+### Test Method Selection
+
+**Use `get_features_for_events` when:**
+- Testing features using Tecton's Aggregation Engine
+- Testing `@batch_feature_view` with `Aggregate` features
+
+**Use `run_transformation` when:**
+- Testing custom SQL transformations without `Aggregate` features
+- Verifying raw transformation output
+- Testing Realtime Feature Views
+
+### Test Structure Best Practices
+
+1. **Test Data Setup**
+   - Clear docstring describing test purpose
+   - Minimal but complete mock input data
+   - Document purpose of each test record
+   - Include edge cases (nulls, zeros, boundaries)
+
+2. **Expected Values**
+   - Calculate expected values manually first
+   - Document calculations in comments
+   - Break down complex calculations into steps
+   - Consider edge cases and expected outcomes
+
+3. **Feature Computation**
+   - Choose appropriate test method
+   - Set up correct time windows
+   - Ensure all required mock inputs provided
+   - Consider batch schedule constraints
+
+4. **Assertions**
+   - Group assertions by feature type
+   - Test both column presence and values
+   - Include descriptive error messages
+   - Use appropriate tolerance for floating-point comparisons
+   - Test NULL values explicitly where expected
+
+### Common Testing Pitfalls to Avoid
+
+- Using PySpark calculations for expected values
+- Not documenting reason for NULL expectations
+- Missing edge cases in test data
+- Not accounting for time window boundaries
+- Using exact equality for floating-point comparisons
+- Not testing both presence and values of features
+- Insufficient error messages in assertions
+- Not considering batch schedule constraints
+- Using deprecated `get_historical_features` method
+- Don't just give up and end up skipping a unit test you've created. Fix it! If you don't know how, ask the user for help
+- Don't ever try to use the `get_historical_features` method. It's deprecated
+
+### Debugging Unit Tests
+
+If unit tests don't return expected values, try the following techniques:
+
+- If the FeatureView is defined using SQL, print the fully assembled SQL query. Analyze the query to ensure it aligns with your expectations.
+  - A common issue is unintended filtering—especially on time ranges—which can silently exclude expected data.
+- If reviewing the SQL isn't enough, inspect the mock data provided to the unit test:
+  - The parameters passed into your FeatureView function typically include temporary table names
+  - You can query those temporary tables directly to see what data is available during the test.
+  - If the temporary tables show less data than you'd expect, a common root cause is that Tecton filters the input data by timestamp. It filters out anything that's not within the start_time and end_time timerange unless you explicitly call ".unfiltered()" on the data source when you reference it in the FV definition's `sources` parameter.
+
+**Detailed Debugging Examples:**
+
+```python
+@batch_feature_view(
+    sources=[transactions_snowflake], 
+    # ...
+)
+def feature_view_name(transactions, context=materialization_context()):
+    # Keep explicit ISO formatting for timestamp
+    end_time_iso = context.end_time.isoformat()
+
+    # Define the SQL f-string, using single braces for source as per docs
+    sql_query = f"""
+    SELECT
+        user_id,
+        AVG(amount) AS avg_transaction_amount_30d,
+        TO_TIMESTAMP('{end_time_iso}') - INTERVAL 1 MICROSECOND AS feature_timestamp
+    FROM {transactions}
+    WHERE transaction_time >= (TO_TIMESTAMP('{end_time_iso}') - INTERVAL 30 DAY)
+      AND transaction_time < TO_TIMESTAMP('{end_time_iso}')
+    GROUP BY
+        user_id
+    """
+
+    print(sql_query)
+
+    from pyspark.sql import SparkSession
+
+    # Get the current Spark session
+    spark = SparkSession.builder.getOrCreate()
+
+    df = spark.sql(f"SELECT * FROM {transactions}")
+
+    # Show the data
+    df.show(truncate=False)
+
+    return sql_query    
+```
+
+**Inspecting Temporary Tables:**
+```python
+from pyspark.sql import SparkSession
+
+# Get the current Spark session
+spark = SparkSession.builder.getOrCreate()
+
+# Replace 'temp_table_name' with the actual name passed into your function
+df = spark.sql("SELECT * FROM temp_table_name")
+
+# Show the data
+df.show(truncate=False)
+```
+
+### Configure the Local Test Spark Session
+
+Tecton provides a Pytest session-scoped `tecton_pytest_spark_session` fixture. However, that Spark session may not be configured correctly for your tests. In that case, you may either configure the Tecton-provided fixture or create your own Spark session.
+
+Here's an example of configuring the Tecton-provided Spark session:
+
+```python
+import pytest
+
+@pytest.fixture(scope="module", autouse=True)
+def configure_spark_session(tecton_pytest_spark_session):
+    # Custom configuration for the spark session.
+    tecton_pytest_spark_session.conf.set("spark.sql.session.timeZone", "UTC")
+```
+
+Here's an example of how to create your own Spark session and provide it to Tecton:
+
+```python
+from importlib import resources
+
+@pytest.fixture(scope="session")
+def my_custom_spark_session():
+    """Returns a custom spark session configured for use in Tecton unit testing."""
+    with resources.path("tecton_spark.jars", "tecton-udfs-spark-3.jar") as path:
+        tecton_udf_jar_path = str(path)
+
+    spark = (
+        SparkSession.builder.appName("my_custom_spark_session")
+        .config("spark.jars", tecton_udf_jar_path)
+        # This short-circuit's Spark's attempt to auto-detect a hostname for the master address, which can lead to
+        # errors on hosts with "unusual" hostnames that Spark believes are invalid.
+        .config("spark.driver.host", "localhost")
+        .config("spark.sql.session.timeZone", "UTC")
+        .getOrCreate()
+    )
+    try:
+        tecton.set_tecton_spark_session(spark)
+        yield spark
+    finally:
+        spark.stop()
+```
+
+### Test Examples
+
+**Realtime Feature View Test:**
+```python
+def test_transaction_amount_is_high(repo_fixture: TestRepo):
+    transaction_amount_is_high = repo_fixture.get_feature_view("transaction_amount_is_high")
+    transaction_request = pandas.DataFrame({"amount": [124, 10001, 34235436234]})
+    
+    mock_context = MockContext(secrets={"my_secret": "my_secret_value"})
+    actual = transaction_amount_is_high.run_transformation(
+        input_data={
+            "transaction_request": transaction_request,
+            "context": mock_context,
+        },
+    ).to_pandas()
+    
+    expected = pandas.DataFrame({"transaction_amount_is_high": [0, 1, 1]})
+    pandas.testing.assert_frame_equal(actual, expected)
+```
+
+**Batch Feature View with Spark:**
+```python
+def test_user_credit_card_issuer_ghf(tecton_pytest_spark_session):
+    input_pandas_df = pandas.DataFrame(
+        {
+            "user_id": ["user_1", "user_2", "user_3", "user_4"],
+            "signup_timestamp": [datetime(2022, 5, 1)] * 4,
+            "cc_num": [1000000000000000, 4000000000000000, 5000000000000000, 6000000000000000],
+        }
+    )
+    input_spark_df = tecton_pytest_spark_session.createDataFrame(input_pandas_df)
+
+    events = pandas.DataFrame(
+        {
+            "user_id": ["user_1", "user_1", "user_2", "user_not_found"],
+            "timestamp": [datetime(2022, 5, 1), datetime(2022, 5, 2), datetime(2022, 6, 1), datetime(2022, 6, 1)],
+        }
+    )
+
+    # Simulate materializing features for May 1st.
+    output = user_credit_card_issuer.get_features_for_events(events, mock_inputs={"fraud_users_batch": input_spark_df})
+
+    actual = output.to_pandas()
+
+    expected = pandas.DataFrame(
+        {
+            "user_id": ["user_1", "user_1", "user_2", "user_not_found"],
+            "timestamp": [datetime(2022, 5, 1), datetime(2022, 5, 2), datetime(2022, 6, 1), datetime(2022, 6, 1)],
+            "user_credit_card_issuer__credit_card_issuer": [None, "other", "Visa", None],
+        }
+    )
+
+    # NOTE: because the Spark join has non-deterministic ordering, it is important to
+    # sort the dataframe to avoid test flakes.
+    actual = actual.sort_values(["user_id", "timestamp"]).reset_index(drop=True)
+    expected = expected.sort_values(["user_id", "timestamp"]).reset_index(drop=True)
+
+    pandas.testing.assert_frame_equal(actual, expected)
+```
+
+**Complete Example of Unit Test for Incremental Materialization:**
+```python
+import pytest
+import pandas as pd
+from pyspark.sql import SparkSession
+from datetime import datetime, timedelta
+from tecton import conf, TestRepo, FeatureView, MaterializationContext
+
+# Configure Tecton to skip online validation during tests
+conf.set("TECTON_SKIP_OBJECT_VALIDATION", "True")
+
+# Helper function to compare Spark DataFrames (handles potential ordering issues)
+def assert_spark_df_equal(actual_df, expected_df):
+    """ Basic comparison of Spark DataFrames by converting to Pandas """
+    # Sort by key columns to ensure order doesn't affect comparison
+    key_cols = ['product_category', 'store_region'] 
+    
+    actual_pdf = actual_df.sort(key_cols).toPandas()
+    expected_pdf = expected_df.sort(key_cols).toPandas()
+    
+    # Basic schema check (column names)
+    assert sorted(actual_pdf.columns) == sorted(expected_pdf.columns), \
+        f"Column mismatch: {sorted(actual_pdf.columns)} vs {sorted(expected_pdf.columns)}"
+    
+    # Reorder columns for consistent comparison
+    expected_pdf = expected_pdf[actual_pdf.columns]
+    
+    pd.testing.assert_frame_equal(actual_pdf, expected_pdf, check_dtype=False, rtol=1e-5)
+
+@pytest.fixture(scope='module')
+def spark(tecton_pytest_spark_session: SparkSession) -> SparkSession:
+    """ Provides the Tecton SparkSession fixture. """
+    return tecton_pytest_spark_session
+
+def test_product_store_performance_features(repo_fixture: TestRepo, spark: SparkSession):
+    """ Tests the product_store_performance_features batch feature view transformation using run_transformation. """
+    
+    # Get the FeatureView object from the repository fixture
+    fv_under_test: FeatureView = repo_fixture.get_feature_view("product_store_performance_features")
+
+    # Define sample input data
+    transactions_data = {
+        'transaction_id': [1, 2, 3, 4, 5, 6],
+        'product_id': [101, 101, 102, 103, 102, 101],
+        'store_id': [1, 2, 1, 1, 2, 1],
+        'transaction_amount': [10.0, 15.0, 20.0, 5.0, 25.0, 12.0],
+        'TRANSACTION_TIMESTAMP': [ 
+            datetime(2022, 6, 15), datetime(2022, 7, 1), datetime(2022, 1, 10), 
+            datetime(2022, 11, 5), datetime(2022, 12, 20), datetime(2021, 12, 30) 
+        ],
+        'transaction_status': ['completed', 'completed', 'completed', 'pending', 'completed', 'completed']
+    }
+    transactions_pdf = pd.DataFrame(transactions_data)
+    transactions_pdf['TRANSACTION_TIMESTAMP'] = pd.to_datetime(transactions_pdf['TRANSACTION_TIMESTAMP'])
+
+    # Convert to Spark DataFrames
+    transactions_df = spark.createDataFrame(transactions_pdf)
+    
+    # Define test timeframe
+    test_end_time = datetime(2023, 1, 1, 0, 0, 0)
+    test_start_time = test_end_time - timedelta(days=1)
+    
+    # Run transformation
+    actual_output_tecton_df = fv_under_test.run_transformation(
+        mock_inputs={"transactions": transactions_df},
+        start_time=test_start_time,
+        end_time=test_end_time
+    )
+    
+    actual_output_df = actual_output_tecton_df.to_spark()
+    
+    # Assertions would go here
+    assert_spark_df_equal(actual_output_df, expected_output_df)
+```
+
+## Command Preferences
+
+- Run linting and typechecking after implementation
+- Use `tecton plan` for validation
+- Use `tecton test` for running unit tests
+- Never commit changes unless explicitly requested

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tecton MCP Server & Cursor Rules
 
-Tecton's Co-Pilot consists of an MCP Server and Cursor rules.
+Tecton's Co-Pilot consists of an MCP Server rules for MCP clients such as Cursor and Claude Code.
 Read this [blog](https://medium.com/p/252221865d26) to learn much more.
 
 > ℹ️ **Info**: This guide will walk you through setting up the Tecton MCP server with **this repository** and configuring your **feature repository** to use it while developing features with Tecton.

--- a/README.md
+++ b/README.md
@@ -7,14 +7,36 @@ Read this [blog](https://medium.com/p/252221865d26) to learn much more.
 
 ## Table of Contents
 
-- [Quick Start](#quick-start)
 - [Tecton MCP Tools](#tecton-mcp-tools)
+- [Quick Start](#quick-start)
+- [Setup Tecton with Cursor](#setup-tecton-mcp-with-cursor)
+- [Setup Tecton with Claude Code](#setup-tecton-mcp-with-claude-code)
 - [Architecture](#architecture)
-- [Setup Tecton with Cursor](#setup-tecton-with-cursor)
-- [Updating the Tecton MCP Server](#updating-the-tecton-mcp-server)
+- [How to Update the Tecton MCP Server](#how-to-update-the-tecton-mcp-server)
 - [How to Use Specific Tecton SDK Version](#how-to-use-specific-tecton-sdk-version)
 - [Troubleshooting](#troubleshooting)
 - [Resources](#resources)
+
+## Tecton MCP Tools
+
+The Tecton MCP server exposes the following tools that can be used by an MCP client such as Cursor or Claude Code:
+
+| Tool Name                               | Description                                                                                                                               |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `query_example_code_snippet_index_tool` | Finds relevant Tecton code examples using a vector database. Helpful for finding usage patterns before writing new Tecton code.           |
+| `query_documentation_index_tool`        | Retrieves Tecton documentation snippets based on a query. Provides context directly from Tecton's official documentation.       |
+| `get_full_tecton_sdk_reference_tool`    | Fetches the complete Tecton SDK reference, including all available classes and functions. Use when a broad overview of the SDK is needed. |
+| `query_tecton_sdk_reference_tool`       | Fetches the Tecton SDK reference for a specified list of classes or functions. Ideal for targeted information on specific SDK components.   |
+
+> ℹ️ **Feature Services**: If the MCP server is configured with a `TECTON_API_KEY` environment variable, the MCP server will register Tecton Feature Services as tools. This makes it possible for agents to query online feature services for fresh features from batch, streaming and real-time data sources.
+
+## Prerequisites
+
+1. Install the `uv` package manager:
+
+   ```bash
+   brew install uv
+   ```
 
 ## Quick Start
 
@@ -25,46 +47,125 @@ Read this [blog](https://medium.com/p/252221865d26) to learn much more.
    cd tecton-mcp
    pwd
    ```
-   
-   **Note:** The path to the directory where you just cloned the repository will be referred to as `<path-to-your-local-clone>` in the following steps. The `pwd` command in the end will tell you what the full path is.
 
-2. Install the uv package manager:
+   **Note:** The directory where you just cloned the repository will be referred to as `<path-to-local-clone>` in the following steps.
 
-   ```bash
-   brew install uv
-   ```
-
-3. Verify your installation by running the following command. Replace `<path-to-your-local-clone>` with the path where you cloned the repository in step&nbsp;1:
+2. Verify your installation by running the following command.
 
    ```bash
-   MCP_SMOKE_TEST=1 uv --directory <path-to-your-local-clone> run mcp run src/tecton_mcp/mcp_server/server.py
+   MCP_SMOKE_TEST=1 uv --directory <path-to-local-clone> run mcp run src/tecton_mcp/mcp_server/server.py
    ```
 
    The command should exit without any errors and print a message similar to `MCP_SMOKE_TEST is set. Exiting after initialization.`. This confirms that your local setup works correctly—Cursor will automatically spawn the MCP server as a subprocess when needed.
 
-4. Configure Cursor (or any other MCP client) with the MCP server (see below)
-
-
-5. Log into your Tecton cluster:
+3. Log into your Tecton cluster to authenticate the Tecton SDK used by the Tecton MCP server:
 
    ```bash
    tecton login yourcluster.tecton.ai
    ```
 
-6. Launch Cursor and start developing features with Tecton's Co-Pilot in Cursor!
+4. Configure Cursor (or any other MCP client) with the MCP server (see below)
+- [Setup Tecton MCP with Cursor](#setup-tecton-with-cursor)
+- [Setup Tecton MCP with Claude Code](#setup-tecton-with-claude-code)
 
-## Tecton MCP Tools
+5. Start AI-Assisted Feature Engineering :-)
 
-The Tecton MCP server exposes the following tools that can be used by an MCP client (like Cursor):
+Now you can go to your **Feature Repository** in Cursor and start using Tecton's Co-Pilot - directly integrated in Cursor.
 
-| Tool Name                               | Description                                                                                                                               |
-| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `query_example_code_snippet_index_tool` | Finds relevant Tecton code examples using a vector database. Helpful for finding usage patterns before writing new Tecton code.           |
-| `query_documentation_index_tool`        | Retrieves Tecton documentation snippets based on a query. Provides context directly from Tecton's official documentation.       |
-| `get_full_tecton_sdk_reference_tool`    | Fetches the complete Tecton SDK reference, including all available classes and functions. Use when a broad overview of the SDK is needed. |
-| `query_tecton_sdk_reference_tool`       | Fetches the Tecton SDK reference for a specified list of classes or functions. Ideal for targeted information on specific SDK components.   |
+View this Loom to see how you can use the integration to build new features: https://www.loom.com/share/3658f665668a41d2b0ea2355b433c616
 
-> ℹ️ **Feature Services**: If the MCP server is configured with a `TECTON_API_KEY` environment variable, the MCP server will register Tecton Feature Services as tools. This makes it possible for agents to query online feature services for fresh features from batch, streaming and real-time data sources.
+## Setup Tecton MCP with Cursor
+
+The following is tested with Cursor 0.48 and above
+
+### Configure the Tecton MCP Server in Cursor
+
+Navigate to Cursor Settings -> MCP Tools and click the "Add a Custome MCP Server" button, which will open Cursor's `mcp.json` file.
+Add the following configuration to this file. Make sure you modify the path `<path-to-local-clone>` to match the directory where you cloned the repository:
+
+```json
+{
+    "mcpServers": {
+        "tecton": {
+            "command": "uv",
+            "args": [
+                "--directory",
+                "<path-to-local-clone>",
+                "run",
+                "mcp",
+                "run",
+                "src/tecton_mcp/mcp_server/server.py"
+            ]
+        }
+    }
+}
+```
+
+### Add Tecton-specific Cursor rules
+
+Symlink the cursorrules from this repository's [`.
+cursor/rules` folder](https://github.com/tecton-ai/tecton-mcp/tree/main/.cursor/rules) into your [feature repository](https://docs.tecton.ai/docs/setting-up-tecton/development-setup/creating-a-feature-repository). Using symlinks ensures that any updates to the original rules will automatically be picked up in your feature repository:
+
+```bash
+# Symlink the entire .cursor directory in your feature repo
+ln -s <path-to-local-clone>/.cursor <path-to-tecton-feature-repo>/.cursor
+```
+
+### Verify that the Cursor <> Tecton MCP Integration is working as expected
+
+To make sure that your integration works as expected, ask the Cursor Agent a question like the following and make sure it's properly invoking your Tecton MCP tools:
+> Query Tecton's Examples Index and tell me something about BatchFeatureViews and how they differ from StreamFeatureViews. Also look at the SDK Reference.
+
+If no calls are made to Tecton MCP tools, you may need to restart Cursor or reload your Cursor window to ensure new tools are properly registered.
+
+## Setup Tecton MCP with Claude Code
+
+Navigate to your Tecton feature respoitory and run the following command.
+
+```bash
+claude mcp add-json tecton-mcp '{
+  "command": "uv",
+  "args": [
+    "--directory",
+    "/Users/ravi/Tecton/tecton-mcp",
+    "run",
+    "mcp",
+    "run",
+    "src/tecton_mcp/mcp_server/server.py"
+  ]
+}'
+```
+
+You should see the following message:
+```txt
+Added stdio MCP server tecton-mcp2 to local config
+```
+
+Next, start `claude` and run `/mcp` to ensure `tecton-mcp` is connected.
+
+```bash
+claude "/mcp"
+```
+
+You should see the following:
+```txt
+tecton-mcp  ✔ connected · Enter to view details
+```
+
+### Add Tecton-specific `CLAUDE.md` rules
+
+Symlink the Tecton-recommended [`CLAUDE.md`](https://github.com/tecton-ai/tecton-mcp/tree/main/CLAUDE.md) into your [feature repository](https://docs.tecton.ai/docs/setting-up-tecton/development-setup/creating-a-feature-repository). Using symlinks ensures that any updates to the original rules will automatically be picked up in your feature repository:
+
+```bash
+ln -s <path-to-local-clone>/CLAUDE.md <path-to-tecton-feature-repo>/CLAUDE.md
+```
+
+## Recommended LLMs
+
+As of June 2025, the following is the stack ranked list of best performing Tecton feature engineering LLMs in Cursor; this list may evolve over time as new models are released:
+- Claude Sonnet 4
+- OpenAI o3
+- Gemini 2.5 pro exp (03-25)
 
 ## Architecture
 
@@ -76,80 +177,13 @@ The overall flow for building features with Tecton MCP looks like:
 
 ![Tecton MCP Flow Chart](img/tecton_mcp_flow_chart.png)
 
-## Setup Tecton with Cursor
-
-The following is tested with Cursor 0.48 and above
-
-### Configure the Tecton MCP Server in Cursor
-
-Navigate to Cursor Settings -> MCP and click the "Add new global MCP server" button, which will edit Cursor's `mcp.json` file.
-Add Tecton as an MCP server. You can use the following config as a starting point - make sure you modify the path `<path-to-your-local-clone>` to match the directory where you cloned the repository:
-
-```json
-{
-    "mcpServers": {
-        "tecton": {
-            "command": "uv",
-            "args": [
-                "--directory",
-                "<path-to-your-local-clone>",
-                "run",
-                "mcp",
-                "run", 
-                "src/tecton_mcp/mcp_server/server.py"
-            ]
-        }
-    }
-}
-```
-
-### Add Cursor rules
-
-Symlink the cursorrules from this repository's [`.
-cursor/rules` folder](https://github.com/tecton-ai/
-tecton-mcp/tree/main/.cursor/rules) into your [feature repository](https://docs.tecton.ai/docs/setting-up-tecton/development-setup/creating-a-feature-repository). Using symlinks ensures that any updates to the original rules will automatically be picked up in your feature repository:
-
-```bash
-# Symlink the entire .cursor directory in your feature repo
-ln -s <path-to-your-local-clone>/.cursor <path-to-your-feature-repo>/.cursor
-```
-
-
-### Tecton Login
-
-Log into your Tecton cluster:
-
-```bash
-    tecton login yourcluster.tecton.ai
-```
-
-### Recommended LLM
-
-As of June 2025, the following is the stack ranked list of best performing Tecton feature engineering LLMs in Cursor; this list may evolve over time as new models are released:
-- Claude Sonnet 4
-- OpenAI o3
-- Gemini 2.5 pro exp (03-25)
-
-### Verify that the Cursor <> Tecton MCP Integration is working as expected
-
-To make sure that your integration works as expected, ask the Cursor Agent a question like the following and make sure it's properly invoking your Tecton MCP tools:
-> Query Tecton's Examples Index and tell me something about BatchFeatureViews and how they differ from StreamFeatureViews. Also look at the SDK Reference.
-
-If no calls are made to Tecton MCP tools, you may need to restart Cursor or reload your Cursor window to ensure new tools are properly registered.
-
-### Start AI-Assisted Feature Engineering :-)
-
-Now you can go to your **Feature Repository** in Cursor and start using Tecton's Co-Pilot - directly integrated in Cursor.
-
-View this Loom to see how you can use the integration to build new features: https://www.loom.com/share/3658f665668a41d2b0ea2355b433c616
-
-## Updating the Tecton MCP Server
+## How to Update the Tecton MCP Server
 
 To update the Tecton MCP server to the latest version:
 
 1. **Pull the latest changes** from the repository:
    ```bash
-   cd <path-to-your-local-clone>
+   cd <path-to-local-clone>
    git pull
    ```
 
@@ -182,13 +216,13 @@ By default, this tool provides guidance for the latest pre-release of the Tecton
 2. **Remove the existing lock-file.** Because `uv.lock` records the dependency graph, you must delete it so that `uv` can resolve the new Tecton version:
 
   ```bash
-  cd <path-to-your-local-clone>
+  cd <path-to-local-clone>
   rm uv.lock
   ```
 
 3. **Re-generate the lock-file** by re-running **Step&nbsp;3** (the `MCP_SMOKE_TEST=1 uv --directory` command) of the [Quick Start](#quick-start) section. (This will download the pinned version into an isolated environment for MCP and re-create `uv.lock`.)
 
-4. **Restart** Cursor so that the new Tecton version is loaded into the MCP virtual environment.   
+4. **Restart** Cursor so that the new Tecton version is loaded into the MCP virtual environment.
 
 *Supported versions:* The tools currently support Tecton ≥ 1.0.0. Code examples are not versioned yet – they always use the latest *stable* SDK – however the documentation and SDK reference indices will now match the version you've pinned.
 
@@ -200,10 +234,10 @@ Make sure that Cursor shows "tecton" as an "Enabled" MCP server in "Cursor Setti
 
 ### Run MCP in Diagnostics Mode
 
-To debug the Tecton MCP Server you can run the following command. Replace `<path-to-your-local-clone>` with the actual path where you cloned the repository:
+To debug the Tecton MCP Server you can run the following command. Replace `<path-to-local-clone>` with the actual path where you cloned the repository:
 
 ```bash
-uv --directory <path-to-your-local-clone> run mcp dev src/tecton_mcp/mcp_server/server.py
+uv --directory <path-to-local-clone> run mcp dev src/tecton_mcp/mcp_server/server.py
 ```
 
 Note: Launching Tecton's MCP Server will take a few seconds because it's loading an embedding model into memory that it uses to search for relevant code snippets.


### PR DESCRIPTION
- Adds instructions for Claude Code to README.md
- Refactor the README.md to make the instructions more obvious and upfront, and move the architecture diagrams to a later section since most readers know roughly how MCP works.
- ports `.cursor/rules` into `CLAUDE.md` (generated with claude code, of course)
- Minor cleanups, e.g. removing redundant `tecton login` steps. 